### PR TITLE
Docs: Link to 'Adding an application' from index.md

### DIFF
--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -4,3 +4,5 @@ For projects using the legacy install/update scripts, see [Migrating old
 templates to Nava Platform CLI](./migrating-from-legacy-template.md).
 
 For starting a new project, see [Starting a new project](./new-project.md)
+
+For an existing project that you would like to add an app to, see [Adding an application](../adding-an-app.md)


### PR DESCRIPTION
Updated the index.md document to include a link to "Adding an application", for cases when someone has an existing project already and needs to add a new application.